### PR TITLE
bug fix for 64bit

### DIFF
--- a/type1seqgen.cpp
+++ b/type1seqgen.cpp
@@ -511,7 +511,7 @@ void confirm(seq_t s)
 void evaluate(seq_t s)
 {
   //int matrix[n][n];
-    int** matrix = (int**) malloc(sizeof(int) * n);
+    int** matrix = (int**) malloc(sizeof(int*) * n);
   //cout << "matrix is: " << endl;
   for (int i = 0; i < n; i++) {
   matrix[i] = (int*) malloc(sizeof(int) * n);


### PR DESCRIPTION
for 64bit programs, the size of the pointer (64 bits) is no longer the size of int (32 bits), changing to int* to fix this